### PR TITLE
Allow sass imports in themes.

### DIFF
--- a/almanac.gemspec
+++ b/almanac.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ri_cal"
   spec.add_dependency "addressable"
   spec.add_dependency "thor"
+  spec.add_dependency "cachy"
+  spec.add_dependency "moneta"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/almanack/configuration.rb
+++ b/lib/almanack/configuration.rb
@@ -2,6 +2,8 @@ require 'net/http'
 require 'uri'
 require 'ri_cal'
 require 'sass'
+require 'cachy'
+require 'moneta'
 
 module Almanack
   class Configuration
@@ -26,6 +28,7 @@ module Almanack
         Pathname.pwd.join('themes'),
         Pathname(__dir__).join('themes')
       ]
+      Cachy.cache_store = cache
     end
 
     def theme_root
@@ -49,6 +52,10 @@ module Almanack
 
     def add_meetup_group(options)
       @event_sources << EventSource::MeetupGroup.new(options)
+    end
+
+    def cache
+      @cache ||= Moneta.new(:LRUHash)
     end
   end
 end

--- a/lib/almanack/event_source/meetup_group.rb
+++ b/lib/almanack/event_source/meetup_group.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'json'
 require 'addressable/uri'
+require 'cachy'
 
 module Almanack
   module EventSource
@@ -43,7 +44,7 @@ module Almanack
 
       def location_from_venue(venue)
         return nil if venue.nil?
-        
+
         %w{ name address_1 address_2 address_3 city state country }.map do |attr|
           venue[attr]
         end.compact.join(', ')
@@ -66,7 +67,7 @@ module Almanack
       end
 
       def results
-        response['results']
+        Cachy.cache(uri.to_s.to_sym, :expires_in => 15 * 60){ puts "miss for #{uri}"; response['results'] }
       end
 
       def uri


### PR DESCRIPTION
As raised in issue #5  - can't use sass imports because the theme folder isn't part of the load_paths.
