### PR TITLE
Replace sass with sassc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache: bundler
 rvm:
 - 2.5.7
 - 2.6.5
-- 2.7.0-preview3
-before_install: gem install bundler -v 2.0.2
+- 2.7.0
+before_install: gem install bundler -v 2.1.3
 addons:
   code_climate:
     repo_token:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    almanack (1.2.0)
+    almanack (1.2.1)
       activesupport
       addressable
       faraday
@@ -122,4 +122,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.2
+   2.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       faraday_middleware
       rack-contrib
       ri_cal
-      sass
+      sassc
       sinatra
       sinatra-contrib
       thor
@@ -16,7 +16,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.1)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -33,11 +33,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    faraday (0.17.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.11.2)
+    ffi (1.11.3)
     hashdiff (1.0.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
@@ -46,7 +46,8 @@ GEM
     minitest (5.13.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
-    mustermann (1.0.3)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
@@ -56,14 +57,11 @@ GEM
     rack (2.0.8)
     rack-contrib (2.1.0)
       rack (~> 2.0)
-    rack-protection (2.0.7)
+    rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (10.5.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     ri_cal (0.8.8)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -78,36 +76,34 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    ruby2_keywords (0.0.1)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sinatra (2.0.7)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.7)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.7)
+    sinatra-contrib (2.0.8.1)
       backports (>= 2.8.2)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.7)
-      sinatra (= 2.0.7)
+      rack-protection (= 2.0.8.1)
+      sinatra (= 2.0.8.1)
       tilt (~> 2.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     vcr (5.0.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.2.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby

--- a/almanack.gemspec
+++ b/almanack.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sinatra"
   spec.add_dependency "sinatra-contrib"
-  spec.add_dependency "sass"
+  spec.add_dependency "sassc"
   spec.add_dependency "ri_cal"
   spec.add_dependency "addressable"
   spec.add_dependency "thor"

--- a/lib/almanack/server.rb
+++ b/lib/almanack/server.rb
@@ -1,7 +1,7 @@
 require "rack/contrib"
 require "sinatra"
 require "sinatra/reloader"
-require "sass"
+require "sassc"
 require "almanack"
 
 module Almanack

--- a/lib/almanack/server/environment.rb
+++ b/lib/almanack/server/environment.rb
@@ -29,8 +29,8 @@ module Almanack
       end
 
       def register_sass_loadpaths!
-        if !Sass.load_paths.include?(theme_stylesheet_path)
-          Sass.load_paths << theme_stylesheet_path
+        if !SassC.load_paths.include?(theme_stylesheet_path)
+          SassC.load_paths << theme_stylesheet_path
         end
       end
     end

--- a/lib/almanack/version.rb
+++ b/lib/almanack/version.rb
@@ -1,6 +1,6 @@
 module Almanack
   CODENAME = "Garlick"
-  VERSION  = "1.2.0"
+  VERSION  = "1.2.1"
   HOMEPAGE = "https://github.com/Aupajo/almanack"
   ISSUES   = "https://github.com/Aupajo/almanack/issues"
 end

--- a/spec/features/sass_features_spec.rb
+++ b/spec/features/sass_features_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Sass rendering", :feature do
     allow(Almanack.config).to receive(:theme_root) { fixture_theme('sassy') }
     get "/stylesheets/imports.css"
     raise last_response.errors unless last_response.errors.empty?
+    normalized_css = last_response.body.gsub(/\s+/, ' ')
+    expect(normalized_css).to include('imports { passes: ok; }')
   end
 
   def fixture_theme(name)

--- a/spec/fixtures/themes/sassy/stylesheets/imports.scss
+++ b/spec/fixtures/themes/sassy/stylesheets/imports.scss
@@ -1,1 +1,3 @@
-@import 'imported';
+@import 'variables';
+
+imports { passes: $passes; }

--- a/spec/fixtures/themes/sassy/stylesheets/variables.scss
+++ b/spec/fixtures/themes/sassy/stylesheets/variables.scss
@@ -1,0 +1,1 @@
+$passes: ok;


### PR DESCRIPTION
Ruby Sass was marked as end-of-life on Apr 4, 2019: sass/ruby-sass@7a50eae